### PR TITLE
Change LSP name

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -279,8 +279,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // Create the language client and start the client.
   client = new LanguageClient(
-    'languageServerExample',
-    'Language Server Example',
+    'CiaoLanguageServer',
+    'Ciao Language Server',
     serverOptions,
     clientOptions
   );


### PR DESCRIPTION
This PR changes the LSP name. Vscode uses that name to identify the server on notifications, like when there's a problem